### PR TITLE
Reboot IOP before installing Special SECRMAN

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,6 +223,8 @@ int main(int argc, char *argv[])
 #endif
     EPRINTF("KELFBINDER: Compiled on %s %s\n", __DATE__, __TIME__);
 #ifdef RESET_IOP
+    while (!SifIopReset("", 0)){};
+    while (!SifIopSync()) {};
     SifInitRpc(0);
     // ONLY ONE OF THE LINES BETWEEN THESE TWO COMMENTS CAN BE ENABLED AT THE SAME TIME
     // while (!SifIopReset("", 0)){}; // common IOP Reset


### PR DESCRIPTION
Certain apps (memory card annihilator) load certain IRX drivers (fakehost and others) Wich cause the IOPRP reboot procedure to fail, this breaks KELFBinder, because special SECRMAN will not remain resident under that situation.

 ~~This PR ensures the SECRMAN driver is loaded on a clean environment, without the IRX modules loaded by the previous app...~~
 
 This PR does not achieve what I need