### PR TITLE
simplify `EXTINST.lua`

### DIFF
--- a/bin/INSTALL/EXTINST.lua
+++ b/bin/INSTALL/EXTINST.lua
@@ -1,12 +1,10 @@
 
-Drawbar(X_MID, Y_MID, 60, Color.new(0, 255, 0)) -- THIS MUST ALWAYS BE THE FIRST LINE OF THE INSTALLATION TABLE FILE. THIS ENSURES THAT SCREEN HALTS AT A GREEN BAR IF SOMETHING FAILS
-
-
 -- IF YOU WANT TO DISABLE INSTALLATION OF EXTRA FILES press L1 on main menu (R1 Enables them back)
-System.log("declaring installation tables for PS2BBL\n")
 
 SYSUPDATE_ICON_SYS = "PS2BBL.icn" -- icon files for memory card update
-SYSUPDATE_ICON_SYS_RES = "INSTALL/ASSETS/"..SYSUPDATE_ICON_SYS
+SYSUPDATE_ICON_SYS_LOCATION = "INSTALL/ASSETS/" --where to find the icon file for memory card update
+SYSUPDATE_ICON_SYS_RES = SYSUPDATE_ICON_SYS_LOCATION..SYSUPDATE_ICON_SYS
+
 --- installation table for memory card.
 MC_INST_TABLE = {
   source = {}, --- holds file locations relative to KELFBinder CWD.
@@ -36,51 +34,24 @@ DVDPL_INST_TABLE = {
   dirs = {} --- contains a list of directory names to be created before writing files to target
 }
 
----parse directory and append paths based on files found inside `SOURCEDIR` into `SOURCE_TABLE` and `DEST_TABLE`.
----if at least 1 file is found, the value of `DESTNTDIR` is added into `MKDIR_TABLE`
----@param SOURCEDIR string
----@param DESTNTDIR string
----@param SOURCE_TABLE table
----@param DEST_TABLE table
----@param MKDIR_TABLE table
-function Update_InstTable(SOURCEDIR, DESTNTDIR, SOURCE_TABLE, DEST_TABLE, MKDIR_TABLE)
-  local tmp = System.listDirectory(SOURCEDIR)
-  local COUNT = 0 -- Ammount of files that will be installed
-  local add_dir = true
-  if tmp == nil then return 0 end
-  for x = 1, #tmp do
-    if not tmp[x].directory then
-        table.insert(SOURCE_TABLE, SOURCEDIR.."/"..tmp[x].name)
-        table.insert(DEST_TABLE,   DESTNTDIR.."/"..tmp[x].name)
-        COUNT = COUNT+1
-    end
-  end
-  if COUNT > 0 then --at least one file will be installed... append to mkdir struct
-    for x = 1, #MKDIR_TABLE do
-      if MKDIR_TABLE[x] == DESTNTDIR then
-        add_dir = false
-      end
-    end
-    if add_dir then
-      table.insert(MKDIR_TABLE, DESTNTDIR)
-    end
-    System.log(string.format("Installation table: %d files listed to be moved from '%s' to target:/%s'\n", COUNT, SOURCEDIR, DESTNTDIR))
-  end
-  return COUNT
-end
+--- Here we declare memory card installation folders (beyond the system update folder)
+Update_InstTable("INSTALL/ASSETS/SYS-CONF", "SYS-CONF", MC_INST_TABLE)
+Update_InstTable("INSTALL/ASSETS/APPS",     "APPS",     MC_INST_TABLE)
+Update_InstTable("INSTALL/ASSETS/BOOT",     "BOOT",     MC_INST_TABLE)
 
-Update_InstTable("INSTALL/ASSETS/SYS-CONF", "SYS-CONF", MC_INST_TABLE.source, MC_INST_TABLE.target, MC_INST_TABLE.dirs)
-Update_InstTable("INSTALL/ASSETS/APPS"  , "APPS"  , MC_INST_TABLE.source, MC_INST_TABLE.target, MC_INST_TABLE.dirs)
-Update_InstTable("INSTALL/ASSETS/BOOT"  , "BOOT"  , MC_INST_TABLE.source, MC_INST_TABLE.target, MC_INST_TABLE.dirs)
+--- HDD full paths look like this: `hdd0:PARTITION:pfs:PATH_INSIDE_PARTITON`
+Update_InstTable("INSTALL/ASSETS/PS2BBL-HDD", "hdd0:__sysconf:pfs:/PS2BBL",   HDD_INST_TABLE)
+Update_InstTable("INSTALL/ASSETS/APPS-HDD",   "hdd0:__common:pfs:/APPS",      HDD_INST_TABLE)
+Update_InstTable("INSTALL/ASSETS/BOOT-HDD",   "hdd0:__sysconf:pfs:/BOOT",     HDD_INST_TABLE)
+Update_InstTable("INSTALL/ASSETS/FSCK",       "hdd0:__system:pfs:/fsck/lang", HDD_INST_TABLE)
 
-Update_InstTable("INSTALL/ASSETS/PS2BBL-HDD", "hdd0:__sysconf:pfs:/PS2BBL", HDD_INST_TABLE.source, HDD_INST_TABLE.target, HDD_INST_TABLE.dirs)
-Update_InstTable("INSTALL/ASSETS/APPS-HDD"  , "hdd0:__common:pfs:/APPS"   , HDD_INST_TABLE.source, HDD_INST_TABLE.target, HDD_INST_TABLE.dirs)
-Update_InstTable("INSTALL/ASSETS/BOOT-HDD"  , "hdd0:__sysconf:pfs:/BOOT"  , HDD_INST_TABLE.source, HDD_INST_TABLE.target, HDD_INST_TABLE.dirs)
+--- The DVDPlayer table is a special case, here, we do not declare a destination folder
+--- because that will be determined by user input when the program rums
+--- hence why we pass an empty string here
+Update_InstTable("INSTALL/ASSETS/DVDPLAYER_FILES", "", DVDPL_INST_TABLE)
 
-Update_InstTable("INSTALL/ASSETS/FSCK", "hdd0:__system:pfs:/fsck/lang", HDD_INST_TABLE.source, HDD_INST_TABLE.target, HDD_INST_TABLE.dirs)
 
-Update_InstTable("INSTALL/ASSETS/DVDPLAYER_FILES", "", DVDPL_INST_TABLE.source, DVDPL_INST_TABLE.target, DVDPL_INST_TABLE.dirs)
-
+---DEBUG: here we list what will be installed
 System.log("MC installation table:\n")
 for x = 1, #MC_INST_TABLE.source do
   System.log(string.format("\t[%s] > [%s]\n", MC_INST_TABLE.source[x], MC_INST_TABLE.target[x]))

--- a/bin/INSTALL/KELFBinder.lua
+++ b/bin/INSTALL/KELFBinder.lua
@@ -39,7 +39,7 @@ end
 if doesFileExist("rom0:DAEMON") then
   Screen.clear(Color.new(0xff, 0, 0))
   Screen.flip()
-  error("\tNAMCO ARCADE DETECTED.\n\tABORTING PROGRAM EXECUTION")
+  error("\tARCADE DETECTED.\n\tABORTING PROGRAM EXECUTION")
 end
 ---PSX
 
@@ -76,9 +76,46 @@ local CHKF = Graphics.loadImageEmbedded(4)
 --if doesFileExist("INSTALL/EXTINST.lua") then dofile("INSTALL/EXTINST.lua") else
 --  System.log("### Could not access INSTALL/EXTINST.lua\n")
 --end
+
+---parse directory and append paths based on files found inside `SOURCEDIR` into `SOURCE_TABLE` and `DEST_TABLE`.
+---if at least 1 file is found, the value of `DESTNTDIR` is added into `MKDIR_TABLE`
+---@param SOURCEDIR string relative path to parse for registering installation files
+---@param DESTNTDIR string destination path on target device
+---@param T table installation table
+function Update_InstTable(SOURCEDIR, DESTNTDIR, T)
+  if type(T.source) ~= "table" or type(T.target) ~= "table" or type(T.dirs) ~= "table" then
+    error("Invalid installation table passed to table updater")
+  end
+  local tmp = System.listDirectory(SOURCEDIR)
+  local COUNT = 0 -- Ammount of files that will be installed
+  local add_dir = true
+  if tmp == nil then return 0 end
+  for x = 1, #tmp do
+    if not tmp[x].directory then
+        table.insert(T.source, SOURCEDIR.."/"..tmp[x].name)
+        table.insert(T.target, DESTNTDIR.."/"..tmp[x].name)
+        COUNT = COUNT+1
+    end
+  end
+  if COUNT > 0 then --at least one file will be installed... append to mkdir struct
+    for x = 1, #T.dirs do
+      if T.dirs[x] == DESTNTDIR then
+        add_dir = false
+      end
+    end
+    if add_dir then
+      table.insert(T.dirs, DESTNTDIR)
+    end
+    System.log(string.format("Installation table: %d files listed to be moved from '%s' to target:/%s'\n", COUNT, SOURCEDIR, DESTNTDIR))
+  end
+  return COUNT
+end
+
+Drawbar(X_MID, Y_MID, 60, Color.new(0, 255, 0))
+System.log("declaring installation tables for PS2BBL\n")
 dofile("INSTALL/EXTINST.lua")
-System.sleep(1)
 Drawbar(X_MID, Y_MID, 70, Color.new(255, 255, 255))
+
 Graphics.setImageFilters(LOGO, LINEAR)
 Graphics.setImageFilters(BG, LINEAR)
 Graphics.setImageFilters(BGERR, LINEAR)


### PR DESCRIPTION
moving forward to make "install asset replacement drop-in packages"

The idea is that developers pack their apps in a single zip that can be unpacked inside `INSTALL/` and thats it